### PR TITLE
Add missing html5lib into requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4~=4.9.3
 pytz~=2020.5
 tzlocal~=2.1
+html5lib~=1.1


### PR DESCRIPTION
Hey! Thanks for the awesome tool 👍 

I got 
```
bs4.FeatureNotFound: Couldn't find a tree builder with the features you requested: html5lib. Do you need to install a parser library?
```
on a clean environment. I suppose `html5lib` needs to be on the list of dependencies.