### PR TITLE
Added html-to-markdown conversion

### DIFF
--- a/j2d.py
+++ b/j2d.py
@@ -12,6 +12,7 @@ from typing import List, Iterable, Optional, Tuple
 from bs4 import BeautifulSoup
 from pytz import timezone as tz, UnknownTimeZoneError
 from tzlocal import get_localzone
+from markdownify import markdownify
 
 
 @dataclass
@@ -160,7 +161,7 @@ class Importer:
                 print('WARNING: coordinates are invalid: {} {}'.format(raw.lat, raw.lon))
 
         skip = False
-        text = self.strip_text_from_html_body(raw.text)
+        text = self.convert_html_to_markdown(raw.text)
         if not text:
             print('WARNING: entry has no text: id={}'.format(raw.id))
         if not text and len(photos) == 0:
@@ -181,11 +182,11 @@ class Importer:
         tag = re.sub(r'\s+', r'\\\g<0>', raw)
         return tag
 
-    def strip_text_from_html_body(self, original_text):
+    def convert_html_to_markdown(self, original_text):
         soup = BeautifulSoup(original_text, 'html5lib')
         is_html = bool(soup.find())  # true if at least one HTML element can be found
         if is_html:
-            return soup.get_text(strip=True)
+            return markdownify(original_text)
         else:
             return original_text
 

--- a/j2d.py
+++ b/j2d.py
@@ -10,9 +10,9 @@ from pathlib import Path
 from typing import List, Iterable, Optional, Tuple
 
 from bs4 import BeautifulSoup
+from markdownify import markdownify
 from pytz import timezone as tz, UnknownTimeZoneError
 from tzlocal import get_localzone
-from markdownify import markdownify
 
 
 @dataclass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 beautifulsoup4~=4.9.3
 pytz~=2020.5
 tzlocal~=2.1
+html5lib~=1.1
+markdownify~=0.10.1


### PR DESCRIPTION
Thanks for the handy tool!

I've lost all the formatting on the newly imported entries because of stripped journey's html. 
I propose to convert journey's html into supported by Day One markdown format.

This is tested on my own heavily formatted entries (~2k in total) – worked perfectly.